### PR TITLE
[ENABLE-220] add cacheGroup param to request obj

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,3 +46,55 @@ Specify a port for the caching server. Defaults to `9926`.
 ### `files: String`
 
 Used to load the necessary JS files.
+
+
+## config.yaml extension options
+
+- clearRestIntervalCount - Number of records to invalidate prior to pausing when /invalidate endpoint is called
+- clearRestIntervalMs - Duration of pause in milliseconds when /invalidate endpoint is called
+- scheduledFullCacheClearTime - Time of day to perform a full cache clear (Expressed as hours in 24-hour format UTC time, i.e. 10.33 = 10:20 AM UTC)
+- additionalCacheDatabaseGroups - Array of additional database groups to use for caching. Each group will create a new database to store cached records.
+
+Example usage:
+
+
+```yaml
+'@harperdb/http-router':
+  package: '@harperdb/http-router'
+  files: '*.*js'
+  clearRestIntervalCount: 1000
+  clearRestIntervalMs: 10
+  scheduledFullCacheClearTime: 10.33
+  additionalCacheDatabaseGroups:
+    - 'api'
+```
+
+## Multi DB Caching
+
+By default, the cache will use a database named `cache` to store cached records. You can specify additional database groups to use for caching via the `additionalCacheDatabaseGroups` configuration option in the `config.yaml` file.
+Each additional database group will create a new database to store cached records. The database group name can optionally be passed as the `cacheGroup` paramater as part of the `edge` caching configuration within the request actions.
+
+i.e.
+
+```js
+cache({
+    edge: {
+      maxAgeSeconds: 10000,
+      staleWhileRevalidateSeconds: 3600,
+      cacheGroup: 'api'
+    }
+})
+```
+
+## Invalidation
+
+Cache can be invalidated via a POST request to /invalidate
+
+This will invalidate records from the default `cache` database. To invalidate records from an additional cache database, use the `x-cache-group` request header to specify the database group name.
+
+i.e.
+
+```
+POST /invalidate
+HEADER: 'x-cache-group: api'
+```

--- a/index.js
+++ b/index.js
@@ -210,8 +210,6 @@ class Router {
 						if (caching.maxAgeSeconds) cacheControlDirectives.push(`s-maxage=${caching.maxAgeSeconds}`);
 						request.cacheKey = keyParts.join('&');
 						// let the caching layer handle the headers
-
-						request.cacheGroup = caching.cacheGroup;
 					}
 					if (caching.forcePrivateCaching) cacheControlDirectives.push('private');
 					if (caching.clientMaxAgeSeconds !== undefined) {
@@ -220,6 +218,8 @@ class Router {
 						else cacheControlDirectives.push(`max-age=${caching.clientMaxAgeSeconds}`);
 					}
 					responseHeaders['Cache-Control'] = cacheControlDirectives.join(', ');
+
+					request.cacheGroup = caching.cacheGroup;
 				} else if (actions.caching === false) {
 					request.cacheKey = undefined;
 				}
@@ -447,6 +447,7 @@ class RequestActions {
 				caching.maxAgeSeconds = options.edge.maxAgeSeconds;
 				caching.staleWhileRevalidateSeconds = options.edge.staleWhileRevalidateSeconds;
 				caching.forcePrivateCaching = options.edge.forcePrivateCaching;
+				caching.cacheGroup = options.edge.cacheGroup;
 			} else if (options.edge === false) actions.caching = false;
 			if (options.browser) {
 				if (options.browser.maxAgeSeconds != null) {

--- a/index.js
+++ b/index.js
@@ -210,6 +210,8 @@ class Router {
 						if (caching.maxAgeSeconds) cacheControlDirectives.push(`s-maxage=${caching.maxAgeSeconds}`);
 						request.cacheKey = keyParts.join('&');
 						// let the caching layer handle the headers
+
+						request.cacheGroup = caching.cacheGroup;
 					}
 					if (caching.forcePrivateCaching) cacheControlDirectives.push('private');
 					if (caching.clientMaxAgeSeconds !== undefined) {

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
 		"format": "prettier --write ."
 	},
 	"dependencies": {
-		"@harperdb/http-cache": "^1.1.1",
+		"@harperdb/http-cache": "^1.2.0",
 		"send": "^1.1.0"
 	},
 	"devDependencies": {


### PR DESCRIPTION
Attaches new `cacheGroup` to request object

To be used with update to [@harperdb/http-cache](https://github.com/HarperFast/http-cache/pull/6)