### PR TITLE
[feature] - Enable option to override request headers before proxying requests

### DIFF
--- a/index.js
+++ b/index.js
@@ -439,6 +439,17 @@ class RequestActions {
 			}
 		};
 	}
+	get setRequestHeader() {
+    let actions = this;
+    return (name, value) => {
+        // Store request header modifications
+        if (!actions.request_headers) actions.request_headers = {};
+        actions.request_headers[name.toLowerCase()] = value;
+    };
+	}
+	get request() {
+		return this._request;
+	}
 	get cache() {
 		let actions = this;
 		return (options) => {

--- a/index.js
+++ b/index.js
@@ -423,7 +423,7 @@ class Rule {
 
 class RequestActions {
 	constructor(request) {
-		this.request = request;
+		this._request = request;
 	}
 	// we do theses as a getters, because the function is accessed through destructuring and called without its
 	// context/this

--- a/index.js
+++ b/index.js
@@ -244,6 +244,11 @@ class Router {
 					const headers = request.headers.asObject;
 					delete headers.host;
 					delete headers.Host;
+
+					if (actions.request_headers) {
+						Object.assign(headers, actions.request_headers)
+					}
+
 					if (originConfig.hostHeader) headers.Host = originConfig.hostHeader;
 					const requestOptions = {
 						timeout: 60000,

--- a/index.js
+++ b/index.js
@@ -447,9 +447,9 @@ class RequestActions {
 	get setRequestHeader() {
     let actions = this;
     return (name, value) => {
-        // Store request header modifications
-        if (!actions.request_headers) actions.request_headers = {};
-        actions.request_headers[name.toLowerCase()] = value;
+			// Store request header modifications
+			if (!actions.request_headers) actions.request_headers = {};
+			actions.request_headers[name.toLowerCase()] = value;
     };
 	}
 	get request() {


### PR DESCRIPTION
It is a straightforward change:

- Making the request available so the cookies can be accessed (and filtered!)
- Making a setRequestHeaders available so a header can be updated by adding it to the actions
- Updating the proxy flow so it checks for the request headers and adds them to the request

P.S.: Somehow, I couldn't get the correct indentation for the `setRequestHeaders` part, even though it looks correct in my branch.